### PR TITLE
Skip checking results for tasks that are not loaded

### DIFF
--- a/rules/no-undefined-result.js
+++ b/rules/no-undefined-result.js
@@ -10,7 +10,8 @@ const checkUndefinedResult = (pipeline, tekton, report) => (value, path, parent)
   const matchingTask = pipeline.spec.tasks.find(t => t.name === task);
   if (!matchingTask) return;
 
-  const taskSpec = matchingTask.taskRef ? tekton.tasks[matchingTask.taskRef.name].spec : matchingTask.taskSpec;
+  const hasTask = matchingTask.taskRef && tekton.tasks[matchingTask.taskRef.name];
+  const taskSpec = hasTask ? tekton.tasks[matchingTask.taskRef.name].spec : matchingTask.taskSpec;
 
   const matchingResult = taskSpec.results.find(result => result.name === name);
   if (!matchingResult) {


### PR DESCRIPTION
In accordance to issue https://github.com/IBM/tekton-lint/issues/1 , this would fix the undefined issue by checking if `tekton.tasks` is undefined.

There's also an added exclamation mark in `tekton.tasks[matchingTask.taskRef.name]!.spec`, to prevent linter issues.