### PR TITLE
feat: add quiet flag

### DIFF
--- a/lint.js
+++ b/lint.js
@@ -19,6 +19,7 @@ $ tekton-lint --version # Show version number
 $ tekton-lint --help    # Show help
 $ tekton-lint --color / --no-color   # Forcefully enable/disable colored output
 $ tekton-lint --format  # Format output. Available formatters: vscode (default) | stylish | json
+$ tekton-lint --quiet   # Report errors only - default: false
 
 Examples:
 # Globstar matching

--- a/log-problems.js
+++ b/log-problems.js
@@ -5,11 +5,14 @@ const formatters = {
   json: require('./formatters/json'),
 };
 
-module.exports = ({ format }, problems) => {
+const onlyErrors = problems => problems.filter(problem => problem.level === 'error');
+
+module.exports = ({ format, quiet }, problems) => {
   if (!(format in formatters)) {
     process.exitCode = 1;
     return console.log(`Formatter "${format}" is not available!`);
   }
 
-  formatters[format](problems);
+  const validProblems = quiet ? onlyErrors(problems) : problems;
+  formatters[format](validProblems);
 };

--- a/readme.markdown
+++ b/readme.markdown
@@ -28,6 +28,7 @@ $ tekton-lint --version # Show version number
 $ tekton-lint --help    # Show help
 $ tekton-lint --color / --no-color   # Forcefully enable/disable colored output
 $ tekton-lint --format  # Format output. Available formatters: vscode (default) | stylish | json
+$ tekton-lint --quiet   # Report errors only - default: false
 
 # exact file path
 $ tekton-lint my-pipeline.yaml my-task.yaml


### PR DESCRIPTION
This PR is related to #10 

### Example
```
node lint.js '**/tekton-beta-mixed.yaml' --quiet
```
### Result
```
regression-tests/tekton-beta-mixed.yaml:
error   (17,7,21,1): Pipeline 'tekton-alpha-mixed-pipeline' references task 'my-task', but parameter 'my-param' is not supplied (it's a required param in 'my-task')
error   (38,7,43,1): Pipeline 'tekton-beta-mixed-pipeline' references task 'my-task', but parameter 'my-param' is not supplied (it's a required param in 'my-task')
```

### Before (without flag)
```
error   (17,7,21,1): Pipeline 'tekton-alpha-mixed-pipeline' references task 'my-task', but parameter 'my-param' is not supplied (it's a required param in 'my-task')
error   (38,7,43,1): Pipeline 'tekton-beta-mixed-pipeline' references task 'my-task', but parameter 'my-param' is not supplied (it's a required param in 'my-task')
warning (8,7,9,1): Task 'tekton-alpha-mixed' defines parameter 'my-param', but it's not used anywhere in the spec
warning (29,9,30,1): Task 'tekton-beta-mixed' defines parameter 'my-param', but it's not used anywhere in the spec
warning (20,11,21,1): Pipeline 'tekton-alpha-mixed-pipeline' is defined with apiVersion tekton.dev/v1alpha1, but defines an inlined task (my-task) with spec.params. Use spec.inputs.params instead.
warning (42,13,43,1): Pipeline 'tekton-beta-mixed-pipeline' is defined with apiVersion tekton.dev/v1beta1, but defines an inlined task (my-task) with spec.inputs.params. Use spec.params instead.
warning (8,5,9,3): Task 'tekton-alpha-mixed' is defined with apiVersion tekton.dev/v1alpha1, but defines spec.params. Use spec.inputs.params instead.
warning (29,7,30,3): Task 'tekton-beta-mixed' is defined with apiVersion tekton.dev/v1beta1, but defined spec.inputs.params. Use spec.params instead.
warning (2,13,2,32): Task 'tekton-alpha-mixed' is defined with apiVersion tekton.dev/v1alpha1, consider migrating to tekton.dev/v1beta1
warning (11,13,11,32): Pipeline 'tekton-alpha-mixed-pipeline' is defined with apiVersion tekton.dev/v1alpha1, consider migrating to tekton.dev/v1beta1
```
