### PR TITLE
Prefer `WhenExpression` over `Condition` rule

### DIFF
--- a/.tektonlintrc.yaml
+++ b/.tektonlintrc.yaml
@@ -22,3 +22,4 @@ rules: # error | warning | off
   no-unused-param: warning
   no-missing-resource: error
   no-undefined-param: error
+  prefer-when-expression: warning

--- a/readme.markdown
+++ b/readme.markdown
@@ -208,6 +208,7 @@ for (const problem of problems) {
 - _kebab-case_ naming violations
 - `Task` & `Pipeline` definitions with `tekton.dev/v1alpha1` `apiVersion`
 - Missing `TriggerBinding` parameter values
+- Usage of deprecated `Condition` instead of `WhenExpression`
 
 [tekton]: https://tekton.dev
 [node]: https://nodejs.org

--- a/regression-tests/__snapshots__/regresion.test.js.snap
+++ b/regression-tests/__snapshots__/regresion.test.js.snap
@@ -179,6 +179,22 @@ Array [
     "rule": "no-invalid-name",
   },
   Object {
+    "level": "warning",
+    "loc": Object {
+      "endColumn": 1,
+      "endLine": 43,
+      "range": Array [
+        773,
+        807,
+      ],
+      "startColumn": 9,
+      "startLine": 42,
+    },
+    "message": "Task 'tekton-without-params' in Pipeline 'pipeline-with-missing-condition' is guarded by condition(s) ('missing-condition'). Conditions are deprecated, use WhenExpressions instead.",
+    "path": "./regression-tests/conditions.yaml",
+    "rule": "prefer-when-expression",
+  },
+  Object {
     "level": "error",
     "loc": Object {
       "endColumn": 1,
@@ -193,6 +209,22 @@ Array [
     "message": "Pipeline 'pipeline-with-missing-condition' references Condition 'missing-condition' but the referenced Condition cannot be found. To fix this, include all the Condition definitions to the lint task for this pipeline.",
     "path": "./regression-tests/conditions.yaml",
     "rule": "no-missing-resource",
+  },
+  Object {
+    "level": "warning",
+    "loc": Object {
+      "endColumn": 1,
+      "endLine": 56,
+      "range": Array [
+        1033,
+        1131,
+      ],
+      "startColumn": 9,
+      "startLine": 54,
+    },
+    "message": "Task 'tekton-without-params' in Pipeline 'pipeline-with-multiple-conditions' is guarded by condition(s) ('condition-with-unused-params, condition-with-unused-params'). Conditions are deprecated, use WhenExpressions instead.",
+    "path": "./regression-tests/conditions.yaml",
+    "rule": "prefer-when-expression",
   },
   Object {
     "level": "warning",

--- a/regression-tests/conditions.yaml
+++ b/regression-tests/conditions.yaml
@@ -40,3 +40,16 @@ spec:
         name: task-without-params
       conditions:
         - conditionRef: missing-condition
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: pipeline-with-multiple-conditions
+spec:
+  tasks:
+    - name: tekton-without-params
+      taskRef:
+        name: task-without-params
+      conditions:
+        - conditionRef: condition-with-unused-params
+        - conditionRef: condition-with-unused-params

--- a/rule-loader.js
+++ b/rule-loader.js
@@ -55,6 +55,9 @@ const rules = {
 
   // prefer-kebab-case
   'prefer-kebab-case': require('./rules/prefer-kebab-case.js'),
+
+  // prefer-when-expression
+  'prefer-when-expression': require('./rules/prefer-when-expression.js'),
 };
 
 module.exports = rules;

--- a/rules/prefer-when-expression.js
+++ b/rules/prefer-when-expression.js
@@ -1,0 +1,10 @@
+module.exports = (docs, tekton, report) => {
+  for (const pipeline of Object.values(tekton.pipelines)) {
+    for (const task of pipeline.spec.tasks) {
+      if (task.conditions) {
+        const guardedBy = task.conditions.map(condition => condition.conditionRef);
+        report(`Task '${task.name}' in Pipeline '${pipeline.metadata.name}' is guarded by condition(s) ('${guardedBy.join(', ')}'). Conditions are deprecated, use WhenExpressions instead.`, task, 'conditions');
+      }
+    }
+  }
+};


### PR DESCRIPTION
Added a rule which warns if deprecated `Condition` is used to guard a `Task` execution instead of `WhenExpression`.
https://github.com/IBM/tekton-lint/issues/3