### PR TITLE
Fixes for array arguments to tasks and images in stepTemplates

### DIFF
--- a/regression-tests/__snapshots__/regresion.test.js.snap
+++ b/regression-tests/__snapshots__/regresion.test.js.snap
@@ -115,6 +115,22 @@ Array [
     "rule": "no-unused-param",
   },
   Object {
+    "level": "error",
+    "loc": Object {
+      "endColumn": 27,
+      "endLine": 31,
+      "range": Array [
+        478,
+        490,
+      ],
+      "startColumn": 15,
+      "startLine": 31,
+    },
+    "message": "Pipeline 'task-param-array-pipeline' references task 'doesnt-exist' but the referenced task cannot be found. To fix this, include all the task definitions to the lint task for this pipeline.",
+    "path": "./regression-tests/array-params.yaml",
+    "rule": "no-missing-resource",
+  },
+  Object {
     "level": "warning",
     "loc": Object {
       "endColumn": 1,

--- a/regression-tests/array-params.yaml
+++ b/regression-tests/array-params.yaml
@@ -19,3 +19,20 @@ spec:
     - name: qux
       default: false
   steps: []
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: task-param-array-pipeline
+spec:
+  tasks:
+    - name: task-param-array-task
+      taskRef:
+        name: doesnt-exist
+      params:
+        - name: compact-args
+          value: ["first", "second"]
+        - name: loose-args
+          value:
+            - "first"
+            - "second"


### PR DESCRIPTION
The following task inside a pipeline causes tekton-lint to crash:
```
    - name: shellcheck-run
      taskRef:
        name: shellcheck
      runAfter:
        - clone-repo
      workspaces:
        - name: shared-workspace
          workspace: pipeline-pvc
      params:
        - name: shellcheck-args
          value: ["--color=always"]
```

or


```
        - name: shellcheck-args
          value:
            - "--color=always"
```

the `shellcheck-args` parameter causes the following error:

```
TypeError: value.match is not a function
    at readParamReference (/src/rules/no-pipeline-task-cycle.js:6:14)
    at /src/rules/no-pipeline-task-cycle.js:18:8
    at Array.map (<anonymous>)
    at paramsReferences (/src/rules/no-pipeline-task-cycle.js:17:17)
    at buildTaskGraph (/src/rules/no-pipeline-task-cycle.js:55:35)
    at errorCyclesInPipeline (/src/rules/no-pipeline-task-cycle.js:67:29)
    at module.exports (/src/rules/no-pipeline-task-cycle.js:78:5)
    at Object.lint (/src/rules.js:52:5)
    at AsyncFunction.lint (/src/runner.js:32:16)
    at runner (/src/runner.js:26:25)
```

There are other ways to solve this than using `toString()`, I'm happy to switch if there's an argument against it. (https://stackoverflow.com/a/27626619)

---

Next up, tekton-lint was crashing on a task definition where the `image` was specified in the stepTemplate and the step didn't have an `image` key.

This should probably result in an additional rule which ensures `image` is in step template if a step doesn't specify an `image`, but it's outside scope of the `no-latest-image` rule.