### PR TITLE
Add `no-deprecated-resource` rule

### DIFF
--- a/.tektonlintrc.yaml
+++ b/.tektonlintrc.yaml
@@ -23,3 +23,4 @@ rules: # error | warning | off
   no-missing-resource: error
   no-undefined-param: error
   prefer-when-expression: warning
+  no-deprecated-resource: warning

--- a/readme.markdown
+++ b/readme.markdown
@@ -209,6 +209,7 @@ for (const problem of problems) {
 - `Task` & `Pipeline` definitions with `tekton.dev/v1alpha1` `apiVersion`
 - Missing `TriggerBinding` parameter values
 - Usage of deprecated `Condition` instead of `WhenExpression`
+- Usage of deprecated resources (resources marked with `tekton.dev/deprecated` label)
 
 [tekton]: https://tekton.dev
 [node]: https://nodejs.org

--- a/regression-tests/__snapshots__/regresion.test.js.snap
+++ b/regression-tests/__snapshots__/regresion.test.js.snap
@@ -230,6 +230,54 @@ Array [
     "level": "warning",
     "loc": Object {
       "endColumn": 32,
+      "endLine": 7,
+      "range": Array [
+        117,
+        121,
+      ],
+      "startColumn": 28,
+      "startLine": 7,
+    },
+    "message": "Task 'deprecated-task' is deprecated!",
+    "path": "./regression-tests/deprecated-resources.yaml",
+    "rule": "no-deprecated-resource",
+  },
+  Object {
+    "level": "warning",
+    "loc": Object {
+      "endColumn": 32,
+      "endLine": 17,
+      "range": Array [
+        278,
+        282,
+      ],
+      "startColumn": 28,
+      "startLine": 17,
+    },
+    "message": "Pipeline 'deprecated-pipeline' is deprecated!",
+    "path": "./regression-tests/deprecated-resources.yaml",
+    "rule": "no-deprecated-resource",
+  },
+  Object {
+    "level": "warning",
+    "loc": Object {
+      "endColumn": 32,
+      "endLine": 26,
+      "range": Array [
+        441,
+        445,
+      ],
+      "startColumn": 28,
+      "startLine": 26,
+    },
+    "message": "TriggerTemplate 'deprecated-triggertemplate' is deprecated!",
+    "path": "./regression-tests/deprecated-resources.yaml",
+    "rule": "no-deprecated-resource",
+  },
+  Object {
+    "level": "warning",
+    "loc": Object {
+      "endColumn": 32,
       "endLine": 2,
       "range": Array [
         16,

--- a/regression-tests/deprecated-resources.yaml
+++ b/regression-tests/deprecated-resources.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: deprecated-task
+  labels:
+    tekton.dev/deprecated: true
+spec:
+  params: []
+  steps: []
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: deprecated-pipeline
+  labels:
+    tekton.dev/deprecated: true
+spec:
+  tasks: []
+---
+apiVersion: tekton.dev/v1alpha1
+kind: TriggerTemplate
+metadata:
+  name: deprecated-triggertemplate
+  labels:
+    tekton.dev/deprecated: true
+spec:
+  resourcetemplates: []

--- a/rule-loader.js
+++ b/rule-loader.js
@@ -58,6 +58,9 @@ const rules = {
 
   // prefer-when-expression
   'prefer-when-expression': require('./rules/prefer-when-expression.js'),
+
+  // no-deprecated-resource
+  'no-deprecated-resource': require('./rules/no-deprecated-resource.js'),
 };
 
 module.exports = rules;

--- a/rules/no-deprecated-resource.js
+++ b/rules/no-deprecated-resource.js
@@ -1,0 +1,10 @@
+module.exports = (docs, tekton, report) => {
+  for (const resources of Object.values(tekton)) {
+    for (const resource of Object.values(resources)) {
+      const labels = resource.metadata.labels;
+      if (labels && labels['tekton.dev/deprecated'] === true) {
+        report(`${resource.kind} '${resource.metadata.name}' is deprecated!`, labels, 'tekton.dev/deprecated');
+      }
+    }
+  }
+};


### PR DESCRIPTION
Added a rule which detects resources marked with `tekton.dev/deprecated` label.
I named the rule `no-deprecated-resource`, but if you have a better naming idea I'll change it 💬. 

https://github.com/IBM/tekton-lint/issues/22