### PR TITLE
feat: process exit on no tekton-definition

### DIFF
--- a/src/lint.ts
+++ b/src/lint.ts
@@ -78,10 +78,15 @@ $ tekton-lint --watch '**/*.yaml'
         const tooManyWarnings = maxWarnings >= 0 && warningCount > maxWarnings;
         // eslint-disable-next-line no-process-env
         if ((hasError || tooManyWarnings) && process.env.NODE_ENV !== 'test') {
-          process.exitCode = 1;
+          return 1;
         }
+        return 0;
       }, (error) => {
-        console.error(error);
+        console.error(error.message);
+        return 1;
+      })
+      .then((code) => {
+        process.exitCode = code;
       });
   }
 })();

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -37,12 +37,17 @@ const parse = docs => ({
 });
 
 export function lint(docs, reporter, config) {
+  docs = docs.filter(doc => doc && doc.metadata && doc.metadata.name);
+  const tekton = parse(docs);
+
+  if (Object.values(tekton).every((definitionKind => Object.keys(definitionKind).length === 0))) {
+    throw Error('No tekton definitions can be found with the given paths');
+  }
+
   reporter = reporter || new Reporter();
   config = config || {
     rules: {},
   };
-  docs = docs.filter(doc => doc && doc.metadata && doc.metadata.name);
-  const tekton = parse(docs);
 
   for (const [name, rule] of Object.entries(rules)) {
     const skipped = config.rules[name] && config.rules[name] === 'off';

--- a/tests/rules.test.js
+++ b/tests/rules.test.js
@@ -1,0 +1,5 @@
+const { default: lint } = require('../lib/runner');
+
+it('linter with no definitions should throw', async () => {
+  await expect(lint([])).rejects.toThrow();
+});


### PR DESCRIPTION
refs: #20 

When there are no tekton-definitions with the given paths, the linter should exit with `1` as error code.