### PR TITLE
refactor: walk function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -974,6 +974,16 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "@types/jest": {
+      "version": "26.0.15",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.15.tgz",
+      "integrity": "sha512-s2VMReFXRg9XXxV+CW9e5Nz8fH2K1aEhwgjUqPPbQd7g95T0laAcvLv032EhFHIa5GHsZ8W7iJEQVaJq6k3Gog==",
+      "dev": true,
+      "requires": {
+        "jest-diff": "^26.0.0",
+        "pretty-format": "^26.0.0"
+      }
+    },
     "@types/json-schema": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
@@ -1526,6 +1536,15 @@
       "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
       "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
       "dev": true
+    },
+    "bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "requires": {
+        "fast-json-stable-stringify": "2.x"
+      }
     },
     "bser": {
       "version": "2.1.1",
@@ -4131,6 +4150,12 @@
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
       "dev": true
     },
+    "lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
+      "dev": true
+    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -4164,6 +4189,12 @@
       "requires": {
         "semver": "^6.0.0"
       }
+    },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
     "makeerror": {
       "version": "1.0.11",
@@ -5941,6 +5972,45 @@
       "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
       "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
       "dev": true
+    },
+    "ts-jest": {
+      "version": "26.4.1",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.4.1.tgz",
+      "integrity": "sha512-F4aFq01aS6mnAAa0DljNmKr/Kk9y4HVZ1m6/rtJ0ED56cuxINGq3Q9eVAh+z5vcYKe5qnTMvv90vE8vUMFxomg==",
+      "dev": true,
+      "requires": {
+        "@types/jest": "26.x",
+        "bs-logger": "0.x",
+        "buffer-from": "1.x",
+        "fast-json-stable-stringify": "2.x",
+        "jest-util": "^26.1.0",
+        "json5": "2.x",
+        "lodash.memoize": "4.x",
+        "make-error": "1.x",
+        "mkdirp": "1.x",
+        "semver": "7.x",
+        "yargs-parser": "20.x"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "dev": true
+        },
+        "yargs-parser": {
+          "version": "20.2.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.3.tgz",
+          "integrity": "sha512-emOFRT9WVHw03QSvN5qor9QQT9+sw5vwxfYweivSMHTcAXPefwVae2FjO7JJjj8hCE4CzPOPeFM83VwT29HCww==",
+          "dev": true
+        }
+      }
     },
     "tslib": {
       "version": "1.13.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   ],
   "scripts": {
     "lint": "eslint --ext ts src",
-    "test": "jest",
+    "test": "npm run build && jest",
     "build": "tsc",
     "coverage": "jest --coverage"
   },
@@ -38,13 +38,28 @@
     "@commitlint/config-conventional": "^11.0.0",
     "@typescript-eslint/eslint-plugin": "^4.4.0",
     "@typescript-eslint/parser": "^4.4.0",
+    "@types/jest": "^26.0.15",
     "eslint": "^6.8.0",
     "husky": "^4.2.3",
     "jest": "^26.0.1",
+    "ts-jest": "^26.4.1",
     "typescript": "^4.0.3"
   },
   "engines": {
     "node": ">= 12.0.0"
+  },
+  "jest": {
+    "roots": [
+      "<rootDir>/tests",
+      "<rootDir>/regression-tests"
+    ],
+    "testMatch": [
+      "**/?(*.)+(spec|test).+(ts|tsx|js)"
+    ],
+    "transform": {
+      "^.+\\.(ts|tsx)$": "ts-jest"
+    },
+    "preset": "ts-jest"
   },
   "husky": {
     "hooks": {

--- a/src/walk.ts
+++ b/src/walk.ts
@@ -1,4 +1,9 @@
-export function walk(node, path, visitor, parent?) {
+export function walk(
+  node: any,
+  path: (string | number)[],
+  visitor: Function,
+  parent?: any
+) {
   if (typeof node === 'string' || typeof node === 'number') {
     visitor(node, path, parent);
   } else if (Array.isArray(node)) {
@@ -13,7 +18,10 @@ export function walk(node, path, visitor, parent?) {
   }
 }
 
-export function pathToString(path) {
+export function pathToString(path: (string | number)[]) {
+  if (!path) {
+    throw Error('Path should contain at least one subpath in it');
+  }
   let str = '';
   for (const segment of path) {
     if (typeof segment == 'number') {

--- a/tests/walk.test.ts
+++ b/tests/walk.test.ts
@@ -1,0 +1,39 @@
+import { pathToString, walk } from '../src/walk';
+
+describe.each([
+    [[], ''],
+    [['somepath'], '.somepath'],
+    [[1, 'path'], '.[1].path'],
+    [['some', 'path'], '.some.path'],
+    [['some', 'other', '2'], '.some.other.2'],
+    [['some', 'other', 2], '.some.other[2]'],
+    [['some', 'other', 2, 'suffix'], '.some.other[2].suffix'],
+    [['some', 'other', 2, 'suffix', 3, 'secondsuffix'], '.some.other[2].suffix[3].secondsuffix'],
+])('path stringifier: ', (originalPath, expectedStringified) => {
+    test(`${originalPath} should be ${expectedStringified}`, () => {
+        expect(pathToString(originalPath)).toBe(expectedStringified);
+    });
+});
+
+it('stringifying empty path should throw an error', () => {
+    expect(() => pathToString(null)).toThrowError()
+})
+
+describe.each([
+    [null, [], 0],
+    [2, [], 1],
+    ['two', [], 1],
+    [{ node: 'node' }, ['node'], 1],
+    [[], ['some', 'existsing', 'path'], 0],
+    [['existingElement'], [], 1],
+    [{ node: [] }, [], 0],
+    [['existingElement', 'anotherExistingElement'], [], 2],
+    [['existingElement', ['anotherExistingElement']], ['existing', 'path'], 2],
+    [['existingElement', ['anotherExistingElement']], [], 2],
+])('should work', (node, path, expectedVisitCalls) => {
+    test(`Node ${JSON.stringify(node)} with path: ${path} should be visited ${expectedVisitCalls} times`, () => {
+        const mockVisitorFn: jest.Mock<any, any> = jest.fn();
+        walk(node, path, mockVisitorFn);
+        expect(mockVisitorFn).toHaveBeenCalledTimes(expectedVisitCalls);
+    });
+});


### PR DESCRIPTION
The snapshot update is sort of redundant imo, but makes an ounce of sense. And in that case we can unify the `walk` function.
I can't predict the negative value of this redundancy in real usage, but I think it would be nice to put the util functions in one place. What do you think?

Sidenote: I added the typed jest and build to the `npm test` to prevent tricky not-builded regression and unit tests at husky hooks.