### PR TITLE
Report duplicated env vars in `stepTemplate.env`

### DIFF
--- a/regression-tests/__snapshots__/regresion.test.js.snap
+++ b/regression-tests/__snapshots__/regresion.test.js.snap
@@ -787,6 +787,22 @@ Array [
     "rule": "no-latest-image",
   },
   Object {
+    "level": "error",
+    "loc": Object {
+      "endColumn": 18,
+      "endLine": 48,
+      "range": Array [
+        733,
+        736,
+      ],
+      "startColumn": 15,
+      "startLine": 48,
+    },
+    "message": "StepTemplate has env variable 'FOO' duplicated in task 'no-duplicate-env-2'.",
+    "path": "./regression-tests/no-duplicate-env.yaml",
+    "rule": "no-duplicate-env",
+  },
+  Object {
     "level": "warning",
     "loc": Object {
       "endColumn": 20,

--- a/src/rules/no-duplicate-env.ts
+++ b/src/rules/no-duplicate-env.ts
@@ -1,5 +1,16 @@
 export default (docs, tekton, report) => {
   for (const task of Object.values<any>(tekton.tasks)) {
+    if (task.spec.stepTemplate && task.spec.stepTemplate.env) {
+      const templateEnvVars = new Set();
+      for (const env of task.spec.stepTemplate.env) {
+        if (!templateEnvVars.has(env.name)) {
+          templateEnvVars.add(env.name);
+        } else {
+          report(`StepTemplate has env variable '${env.name}' duplicated in task '${task.metadata.name}'.`, env, 'name');
+        }
+      }
+    }
+
     for (const step of task.spec.steps) {
       if (!step.env) continue;
       const envVariables = new Set();


### PR DESCRIPTION
Modified the `no-duplicate-env` rule to also report the duplicated env vars from `stepTemplate.env`.

https://github.com/IBM/tekton-lint/issues/33