### PR TITLE
Run `build` only on `prepare`

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
   ],
   "scripts": {
     "lint": "eslint --ext ts src",
-    "test": "npm run build && jest",
+    "test": "jest",
     "build": "tsc",
+    "prepare": "npm run build",
     "coverage": "jest --coverage"
   },
   "version": "0.5.2",

--- a/regression-tests/regresion.test.js
+++ b/regression-tests/regresion.test.js
@@ -1,5 +1,5 @@
-const collect = require('../lib/Collector').default;
-const { default: runner, lint } = require('../lib/runner');
+const collect = require('../src/Collector').default;
+const { default: runner, lint } = require('../src/runner');
 
 it('regression tests with location', async () => {
   const result = await runner(['./regression-tests/*.yaml']);

--- a/tests/rules.test.js
+++ b/tests/rules.test.js
@@ -1,4 +1,4 @@
-const { default: lint } = require('../lib/runner');
+const { default: lint } = require('../src/runner');
 
 it('linter with no definitions should throw', async () => {
   await expect(lint([])).rejects.toThrow();


### PR DESCRIPTION
Tests should rely on `src`, so `ts-jest` can compile them on-the-fly. `prepare` will make sure that `build` happens when you `npm install`, and before `npm publish`.