### PR TITLE
Add `no-missing-hashbang` rule

### DIFF
--- a/.tektonlintrc.yaml
+++ b/.tektonlintrc.yaml
@@ -22,3 +22,4 @@ rules: # error | warning | off
   no-undefined-param: error
   prefer-when-expression: warning
   no-deprecated-resource: warning
+  no-missing-hashbang: warning

--- a/readme.markdown
+++ b/readme.markdown
@@ -210,6 +210,7 @@ for (const problem of problems) {
 - Missing `TriggerBinding` parameter values
 - Usage of deprecated `Condition` instead of `WhenExpression`
 - Usage of deprecated resources (resources marked with `tekton.dev/deprecated` label)
+- Missing `hashbang` line from a `Step`s `script`
 
 ### Configuring `tekton-lint`
 

--- a/regression-tests/__snapshots__/regresion.test.js.snap
+++ b/regression-tests/__snapshots__/regresion.test.js.snap
@@ -1478,6 +1478,22 @@ Array [
     "level": "warning",
     "loc": Object {
       "endColumn": 1,
+      "endLine": 24,
+      "range": Array [
+        376,
+        398,
+      ],
+      "startColumn": 15,
+      "startLine": 22,
+    },
+    "message": "Step script 'step-1' in Task 'no-missing-hashbang-2' should start with a hashbang line.",
+    "path": "./regression-tests/no-missing-hashbang.yaml",
+    "rule": "no-missing-hashbang",
+  },
+  Object {
+    "level": "warning",
+    "loc": Object {
+      "endColumn": 1,
       "endLine": 9,
       "range": Array [
         103,
@@ -2961,6 +2977,22 @@ Array [
     "message": "In Pipeline 'my-pipeline-with-undefined-result-reference' the value on path '.spec.tasks[1].params[1].value' refers to an undefined output result (as '$(tasks.first-task.results.bar)' - 'bar' is not a result in Task 'first-task')",
     "path": "./regression-tests/pipeline-test.yaml",
     "rule": "no-undefined-result",
+  },
+  Object {
+    "level": "warning",
+    "loc": Object {
+      "endColumn": 61,
+      "endLine": 392,
+      "range": Array [
+        9259,
+        9305,
+      ],
+      "startColumn": 15,
+      "startLine": 392,
+    },
+    "message": "Step script 'my-step' in Task 'bar-task-result' should start with a hashbang line.",
+    "path": "./regression-tests/pipeline-test.yaml",
+    "rule": "no-missing-hashbang",
   },
   Object {
     "level": "error",
@@ -4993,6 +5025,22 @@ Array [
     "message": "Pipeline 'tekton-beta-mixed-pipeline' is defined with apiVersion tekton.dev/v1beta1, but defines an inlined task (my-task) with spec.inputs.params. Use spec.params instead.",
     "path": "./regression-tests/tekton-beta-mixed.yaml",
     "rule": "prefer-beta",
+  },
+  Object {
+    "level": "warning",
+    "loc": Object {
+      "endColumn": 1,
+      "endLine": 58,
+      "range": Array [
+        936,
+        1011,
+      ],
+      "startColumn": 15,
+      "startLine": 56,
+    },
+    "message": "Step script 'script' in Task 'tekton-task-with-4-params' should start with a hashbang line.",
+    "path": "./regression-tests/tekton-beta-mixed.yaml",
+    "rule": "no-missing-hashbang",
   },
   Object {
     "level": "warning",

--- a/regression-tests/no-missing-hashbang.yaml
+++ b/regression-tests/no-missing-hashbang.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: no-missing-hashbang-1
+spec:
+  steps:
+    - name: step-1
+      image: alpine@sha256:abc123
+      script: |
+        #!/bin/sh
+        echo "noop"
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: no-missing-hashbang-2
+spec:
+  steps:
+    - name: step-1
+      image: alpine@sha256:abc123
+      script: |
+        echo "noop"

--- a/src/rule-loader.ts
+++ b/src/rule-loader.ts
@@ -59,6 +59,9 @@ const rules = {
 
   // no-deprecated-resource
   'no-deprecated-resource': require('./rules/no-deprecated-resource').default,
+
+  // no-missing-hashbang
+  'no-missing-hashbang': require('./rules/no-missing-hashbang').default,
 };
 
 export default rules;

--- a/src/rules/no-missing-hashbang.ts
+++ b/src/rules/no-missing-hashbang.ts
@@ -1,0 +1,11 @@
+export default (docs, tekton, report) => {
+  const hashbangRegexp = /^#!(.*)/;
+  for (const task of Object.values<any>(tekton.tasks)) {
+    for (const step of task.spec.steps) {
+      if (!step.script) continue;
+      if (!hashbangRegexp.test(step.script)) {
+        report(`Step script '${step.name}' in Task '${task.metadata.name}' should start with a hashbang line.`, step, 'script');
+      }
+    }
+  }
+};


### PR DESCRIPTION
Added a new rule which warns when a hashbang line is missing from a `Step`s `script`.
https://github.com/IBM/tekton-lint/issues/58