### PR TITLE
Fix regression test comment

### DIFF
--- a/regression-tests/__snapshots__/regresion.test.js.snap
+++ b/regression-tests/__snapshots__/regresion.test.js.snap
@@ -1385,7 +1385,7 @@ Array [
       "endLine": 104,
       "range": Array [
         1814,
-        1834,
+        1830,
       ],
       "startColumn": 7,
       "startLine": 103,
@@ -1400,8 +1400,8 @@ Array [
       "endColumn": 1,
       "endLine": 105,
       "range": Array [
-        1840,
-        1863,
+        1836,
+        1859,
       ],
       "startColumn": 7,
       "startLine": 104,
@@ -1416,8 +1416,8 @@ Array [
       "endColumn": 29,
       "endLine": 104,
       "range": Array [
-        1846,
-        1862,
+        1842,
+        1858,
       ],
       "startColumn": 13,
       "startLine": 104,

--- a/regression-tests/no-invalid-name.yaml
+++ b/regression-tests/no-invalid-name.yaml
@@ -100,6 +100,6 @@ spec:
     - name: foo_1-bar # ok
     - name: 1-foo # not ok
     - name: -foo # not ok
-    - name: _foo # not ok
+    - name: _foo # ok
     - name: foo$bar # not ok
   steps: []


### PR DESCRIPTION
`_foo` is a totally valid parameter name, only `-` and numbers are not allowed.