### PR TITLE
Add `source-map-support`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1558,8 +1558,7 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-      "dev": true
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "cache-base": {
       "version": "1.0.1",
@@ -5524,8 +5523,7 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "source-map-resolve": {
       "version": "0.5.3",
@@ -5541,10 +5539,9 @@
       }
     },
     "source-map-support": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
-      "dev": true,
+      "version": "0.5.20",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.20.tgz",
+      "integrity": "sha512-n1lZZ8Ve4ksRqizaBQgxXDgKwttHDhyfQjA6YZZn8+AroHbsIz+JjwxQDxbp+7y5OYCI8t1Yk7etjD9CRd2hIw==",
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "fast-glob": "^3.2.2",
     "graphlib": "^2.1.8",
     "minimist": "^1.2.5",
+    "source-map-support": "^0.5.20",
     "strip-ansi": "^6.0.0",
     "text-table": "^0.2.0",
     "yaml": "^1.8.2"

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import 'source-map-support/register';
 import minimist from 'minimist';
 import watch from './watch';
 import run from './runner';
@@ -82,7 +83,7 @@ $ tekton-lint --watch '**/*.yaml'
         }
         return 0;
       }, (error) => {
-        console.error(error.message);
+        console.error(error);
         return 1;
       })
       .then((code) => {


### PR DESCRIPTION
This way we can interpret the whole error stack trace, not just the error message:
```sh
tekton-lint(main) » tekton-lint test.yaml
TypeError: Cannot read property 'key' of undefined
    at getLocation (/Users/tamas/Private/tekton-lint/src/reporter.ts:23:65)
    at Reporter.report (/Users/tamas/Private/tekton-lint/src/reporter.ts:91:10)
    at /Users/tamas/Private/tekton-lint/src/rules.ts:8:14
    at exports.default (/Users/tamas/Private/tekton-lint/src/rules/no-missing-resource.ts:17:9)
    at Object.lint (/Users/tamas/Private/tekton-lint/src/rules.ts:58:5)
    at lint (/Users/tamas/Private/tekton-lint/src/runner.ts:32:10)
    at Object.runner [as default] (/Users/tamas/Private/tekton-lint/src/runner.ts:38:10)
```
instead of:
```sh
tekton-lint(main) » tekton-lint test.yaml
Cannot read property 'key' of undefined
```