### PR TITLE
fix: handle new eventlistener syntax

### DIFF
--- a/regression-tests/__snapshots__/regresion.test.js.snap
+++ b/regression-tests/__snapshots__/regresion.test.js.snap
@@ -755,6 +755,38 @@ Array [
     "rule": "no-missing-resource",
   },
   Object {
+    "level": "error",
+    "loc": Object {
+      "endColumn": 31,
+      "endLine": 25,
+      "range": Array [
+        462,
+        479,
+      ],
+      "startColumn": 14,
+      "startLine": 25,
+    },
+    "message": "EventListener 'uses-ref' defines trigger template 'pipeline-template', but the trigger template is missing.",
+    "path": "./regression-tests/eventlistener-test.yaml",
+    "rule": "no-missing-resource",
+  },
+  Object {
+    "level": "error",
+    "loc": Object {
+      "endColumn": 32,
+      "endLine": 36,
+      "range": Array [
+        658,
+        675,
+      ],
+      "startColumn": 15,
+      "startLine": 36,
+    },
+    "message": "EventListener 'uses-name' defines trigger template 'pipeline-template', but the trigger template is missing.",
+    "path": "./regression-tests/eventlistener-test.yaml",
+    "rule": "no-missing-resource",
+  },
+  Object {
     "level": "warning",
     "loc": Object {
       "endColumn": 32,

--- a/regression-tests/eventlistener-test.yaml
+++ b/regression-tests/eventlistener-test.yaml
@@ -12,6 +12,29 @@ spec:
         name: binding-missing
     - template:
         name: template-missing
+---
+apiVersion: tekton.dev/v1beta1
+kind: EventListener
+metadata:
+  name: uses-ref
+spec:
+  triggers:
+    - bindings:
+        name: pipeline-binding
+      template:
+        ref: pipeline-template
+---
+apiVersion: tekton.dev/v1beta1
+kind: EventListener
+metadata:
+  name: uses-name
+spec:
+  triggers:
+    - bindings:
+        name: pipeline-binding
+      template:
+        name: pipeline-template
+
 # Tekton linter should handle EventListener bindings
 # ---
 # apiVersion: tekton.dev/v1alpha1

--- a/src/rules/no-missing-resource.ts
+++ b/src/rules/no-missing-resource.ts
@@ -9,15 +9,20 @@ export default (docs, tekton, report) => {
     }
   }
 
-  for (const listener of Object.values<any>(tekton.listeners)) {
-    for (const trigger of listener.spec.triggers) {
-      if (!trigger.template) continue;
-      const name = trigger.template.name;
-      if (!tekton.triggerTemplates[name]) {
-        report(`EventListener '${listener.metadata.name}' defines trigger template '${name}', but the trigger template is missing.`, trigger.template, 'name');
-      }
-    }
-  }
+ for (const listener of Object.values<any>(tekton.listeners)) {
+   for (const trigger of listener.spec.triggers) {
+     if (!trigger.template) continue;
+     const triggerReference = trigger.template.name ?? trigger.template.ref;
+     const referenceKey = trigger.template.name ? 'name' : 'ref';
+     if (!tekton.triggerTemplates[triggerReference]) {
+       report(
+         `EventListener '${listener.metadata.name}' defines trigger template '${triggerReference}', but the trigger template is missing.`,
+         trigger.template,
+         referenceKey
+       );
+     }
+   }
+ }
 
   for (const template of Object.values<any>(tekton.triggerTemplates)) {
     for (const resourceTemplate of template.spec.resourcetemplates) {


### PR DESCRIPTION
The following stacktrace appeared when linting an eventlistener:

```
TypeError: Cannot read property 'key' of undefined
    at getLocation (/tekton-lint/src/reporter.ts:23:65)
    at Reporter.report (/tekton-lint/src/reporter.ts:91:10)
    at /tekton-lint/src/rules.ts:8:14
    at exports.default (/tekton-lint/src/rules/no-missing-resource.ts:25:9)
    at Object.lint (/tekton-lint/src/rules.ts:58:5)
    at lint (/tekton-lint/src/runner.ts:32:10)
    at Object.runner [as default] (/tekton-lint/src/runner.ts:38:10)
```

The fix:
- trigger template can either be referenced by `ref` key or `name` key 
- updated the regression tests
