### PR TITLE
fix: failing no-invalid-name test

### DIFF
--- a/regression-tests/general/no-invalid-name.yaml.expect.json
+++ b/regression-tests/general/no-invalid-name.yaml.expect.json
@@ -1,1 +1,410 @@
-[{"message":"Task 'no-invalid-name' defines parameter '1-foo' with invalid parameter name (names are limited to alpha-numeric characters, '-' and '_' and can only start with alpha characters and '_')","rule":"no-invalid-name","level":"error","path":"./regression-tests/general/no-invalid-name.yaml","loc":{"range":[1767,1772,1782],"startLine":101,"startColumn":13,"endLine":101,"endColumn":18}},{"message":"Task 'no-invalid-name' defines parameter '-foo' with invalid parameter name (names are limited to alpha-numeric characters, '-' and '_' and can only start with alpha characters and '_')","rule":"no-invalid-name","level":"error","path":"./regression-tests/general/no-invalid-name.yaml","loc":{"range":[1794,1798,1808],"startLine":102,"startColumn":13,"endLine":102,"endColumn":17}},{"message":"Task 'no-invalid-name' defines parameter 'foo$bar' with invalid parameter name (names are limited to alpha-numeric characters, '-' and '_' and can only start with alpha characters and '_')","rule":"no-invalid-name","level":"error","path":"./regression-tests/general/no-invalid-name.yaml","loc":{"range":[1842,1849,1859],"startLine":104,"startColumn":13,"endLine":104,"endColumn":20}},{"message":"Invalid name for Task 'no-invalid-name-FooBar'. Names should be in lowercase, alphanumeric, kebab-case format. and follow DNS subdomain names","rule":"no-invalid-name","level":"error","path":"./regression-tests/general/no-invalid-name.yaml","loc":{"range":[64,86,96],"startLine":5,"startColumn":9,"endLine":5,"endColumn":31}},{"message":"Invalid name for Task '-no-invalid-name'. Names should be in lowercase, alphanumeric, kebab-case format. and follow DNS subdomain names","rule":"no-invalid-name","level":"error","path":"./regression-tests/general/no-invalid-name.yaml","loc":{"range":[178,194,204],"startLine":12,"startColumn":9,"endLine":12,"endColumn":25}},{"message":"Invalid name for Task '.no-invalid-name'. Names should be in lowercase, alphanumeric, kebab-case format. and follow DNS subdomain names","rule":"no-invalid-name","level":"error","path":"./regression-tests/general/no-invalid-name.yaml","loc":{"range":[394,410,420],"startLine":26,"startColumn":9,"endLine":26,"endColumn":25}},{"message":"Invalid name for Task 'no-invalid-name_foo'. Names should be in lowercase, alphanumeric, kebab-case format. and follow DNS subdomain names","rule":"no-invalid-name","level":"error","path":"./regression-tests/general/no-invalid-name.yaml","loc":{"range":[610,629,639],"startLine":40,"startColumn":9,"endLine":40,"endColumn":28}},{"message":"Invalid name for Task '1-no-invalid-name'. Names should be in lowercase, alphanumeric, kebab-case format. and follow DNS subdomain names","rule":"no-invalid-name","level":"error","path":"./regression-tests/general/no-invalid-name.yaml","loc":{"range":[828,845,851],"startLine":54,"startColumn":9,"endLine":54,"endColumn":26}},{"message":"Invalid name for PipelineRun '-run-$(uid)'. Names should be in lowercase, alphanumeric, kebab-case format. and follow DNS subdomain names","rule":"no-invalid-name","level":"error","path":"./regression-tests/general/no-invalid-name.yaml","loc":{"range":[1356,1367,1377],"startLine":81,"startColumn":15,"endLine":81,"endColumn":26}},{"message":"TriggerTemplate 'no-invalid-name' references pipeline 'no-invalid-name', but the referenced pipeline cannot be found.","rule":"no-missing-resource","level":"error","path":"./regression-tests/general/no-invalid-name.yaml","loc":{"range":[1249,1264,1265],"startLine":77,"startColumn":17,"endLine":77,"endColumn":32}},{"message":"TriggerTemplate 'no-invalid-name' references pipeline 'no-invalid-name', but the referenced pipeline cannot be found.","rule":"no-missing-resource","level":"error","path":"./regression-tests/general/no-invalid-name.yaml","loc":{"range":[1426,1441,1442],"startLine":84,"startColumn":17,"endLine":84,"endColumn":32}},{"message":"Task 'no-invalid-name' defines parameter 'foo', but it's not used anywhere in the spec","rule":"no-unused-param","level":"warning","path":"./regression-tests/general/no-invalid-name.yaml","loc":{"range":[1544,1559,1559],"startLine":92,"startColumn":7,"endLine":93,"endColumn":1}},{"message":"Task 'no-invalid-name' defines parameter 'foo-', but it's not used anywhere in the spec","rule":"no-unused-param","level":"warning","path":"./regression-tests/general/no-invalid-name.yaml","loc":{"range":[1565,1581,1581],"startLine":93,"startColumn":7,"endLine":94,"endColumn":1}},{"message":"Task 'no-invalid-name' defines parameter 'foo_', but it's not used anywhere in the spec","rule":"no-unused-param","level":"warning","path":"./regression-tests/general/no-invalid-name.yaml","loc":{"range":[1587,1603,1603],"startLine":94,"startColumn":7,"endLine":95,"endColumn":1}},{"message":"Task 'no-invalid-name' defines parameter 'FOO_BAR', but it's not used anywhere in the spec","rule":"no-unused-param","level":"warning","path":"./regression-tests/general/no-invalid-name.yaml","loc":{"range":[1609,1628,1628],"startLine":95,"startColumn":7,"endLine":96,"endColumn":1}},{"message":"Task 'no-invalid-name' defines parameter 'FooBar', but it's not used anywhere in the spec","rule":"no-unused-param","level":"warning","path":"./regression-tests/general/no-invalid-name.yaml","loc":{"range":[1634,1652,1652],"startLine":96,"startColumn":7,"endLine":97,"endColumn":1}},{"message":"Task 'no-invalid-name' defines parameter 'fooBar', but it's not used anywhere in the spec","rule":"no-unused-param","level":"warning","path":"./regression-tests/general/no-invalid-name.yaml","loc":{"range":[1658,1676,1676],"startLine":97,"startColumn":7,"endLine":98,"endColumn":1}},{"message":"Task 'no-invalid-name' defines parameter 'foo-bar', but it's not used anywhere in the spec","rule":"no-unused-param","level":"warning","path":"./regression-tests/general/no-invalid-name.yaml","loc":{"range":[1682,1701,1701],"startLine":98,"startColumn":7,"endLine":99,"endColumn":1}},{"message":"Task 'no-invalid-name' defines parameter 'foo-1-bar', but it's not used anywhere in the spec","rule":"no-unused-param","level":"warning","path":"./regression-tests/general/no-invalid-name.yaml","loc":{"range":[1707,1728,1728],"startLine":99,"startColumn":7,"endLine":100,"endColumn":1}},{"message":"Task 'no-invalid-name' defines parameter 'foo_1-bar', but it's not used anywhere in the spec","rule":"no-unused-param","level":"warning","path":"./regression-tests/general/no-invalid-name.yaml","loc":{"range":[1734,1755,1755],"startLine":100,"startColumn":7,"endLine":101,"endColumn":1}},{"message":"Task 'no-invalid-name' defines parameter '1-foo', but it's not used anywhere in the spec","rule":"no-unused-param","level":"warning","path":"./regression-tests/general/no-invalid-name.yaml","loc":{"range":[1761,1782,1782],"startLine":101,"startColumn":7,"endLine":102,"endColumn":1}},{"message":"Task 'no-invalid-name' defines parameter '-foo', but it's not used anywhere in the spec","rule":"no-unused-param","level":"warning","path":"./regression-tests/general/no-invalid-name.yaml","loc":{"range":[1788,1808,1808],"startLine":102,"startColumn":7,"endLine":103,"endColumn":1}},{"message":"Task 'no-invalid-name' defines parameter '_foo', but it's not used anywhere in the spec","rule":"no-unused-param","level":"warning","path":"./regression-tests/general/no-invalid-name.yaml","loc":{"range":[1814,1830,1830],"startLine":103,"startColumn":7,"endLine":104,"endColumn":1}},{"message":"Task 'no-invalid-name' defines parameter 'foo$bar', but it's not used anywhere in the spec","rule":"no-unused-param","level":"warning","path":"./regression-tests/general/no-invalid-name.yaml","loc":{"range":[1836,1859,1859],"startLine":104,"startColumn":7,"endLine":105,"endColumn":1}}]
+[
+  {
+    "message": "Task 'no-invalid-name' defines parameter '1-foo' with invalid parameter name (names are limited to alpha-numeric characters, '-' and '_' and can only start with alpha characters and '_')",
+    "rule": "no-invalid-name",
+    "level": "error",
+    "path": "./regression-tests/general/no-invalid-name.yaml",
+    "loc": {
+      "range": [
+        1767,
+        1772,
+        1782
+      ],
+      "startLine": 101,
+      "startColumn": 13,
+      "endLine": 101,
+      "endColumn": 18
+    }
+  },
+  {
+    "message": "Task 'no-invalid-name' defines parameter '-foo' with invalid parameter name (names are limited to alpha-numeric characters, '-' and '_' and can only start with alpha characters and '_')",
+    "rule": "no-invalid-name",
+    "level": "error",
+    "path": "./regression-tests/general/no-invalid-name.yaml",
+    "loc": {
+      "range": [
+        1794,
+        1798,
+        1808
+      ],
+      "startLine": 102,
+      "startColumn": 13,
+      "endLine": 102,
+      "endColumn": 17
+    }
+  },
+  {
+    "message": "Task 'no-invalid-name' defines parameter 'foo$bar' with invalid parameter name (names are limited to alpha-numeric characters, '-' and '_' and can only start with alpha characters and '_')",
+    "rule": "no-invalid-name",
+    "level": "error",
+    "path": "./regression-tests/general/no-invalid-name.yaml",
+    "loc": {
+      "range": [
+        1842,
+        1849,
+        1859
+      ],
+      "startLine": 104,
+      "startColumn": 13,
+      "endLine": 104,
+      "endColumn": 20
+    }
+  },
+  {
+    "message": "Invalid name for Task 'no-invalid-name-FooBar'. Names should be in lowercase, alphanumeric, kebab-case format. and follow DNS subdomain names",
+    "rule": "no-invalid-name",
+    "level": "error",
+    "path": "./regression-tests/general/no-invalid-name.yaml",
+    "loc": {
+      "range": [
+        64,
+        86,
+        96
+      ],
+      "startLine": 5,
+      "startColumn": 9,
+      "endLine": 5,
+      "endColumn": 31
+    }
+  },
+  {
+    "message": "Invalid name for Task '-no-invalid-name'. Names should be in lowercase, alphanumeric, kebab-case format. and follow DNS subdomain names",
+    "rule": "no-invalid-name",
+    "level": "error",
+    "path": "./regression-tests/general/no-invalid-name.yaml",
+    "loc": {
+      "range": [
+        178,
+        194,
+        204
+      ],
+      "startLine": 12,
+      "startColumn": 9,
+      "endLine": 12,
+      "endColumn": 25
+    }
+  },
+  {
+    "message": "Invalid name for Task '.no-invalid-name'. Names should be in lowercase, alphanumeric, kebab-case format. and follow DNS subdomain names",
+    "rule": "no-invalid-name",
+    "level": "error",
+    "path": "./regression-tests/general/no-invalid-name.yaml",
+    "loc": {
+      "range": [
+        394,
+        410,
+        420
+      ],
+      "startLine": 26,
+      "startColumn": 9,
+      "endLine": 26,
+      "endColumn": 25
+    }
+  },
+  {
+    "message": "Invalid name for Task 'no-invalid-name_foo'. Names should be in lowercase, alphanumeric, kebab-case format. and follow DNS subdomain names",
+    "rule": "no-invalid-name",
+    "level": "error",
+    "path": "./regression-tests/general/no-invalid-name.yaml",
+    "loc": {
+      "range": [
+        610,
+        629,
+        639
+      ],
+      "startLine": 40,
+      "startColumn": 9,
+      "endLine": 40,
+      "endColumn": 28
+    }
+  },
+  {
+    "message": "Invalid name for Task '1-no-invalid-name'. Names should be in lowercase, alphanumeric, kebab-case format. and follow DNS subdomain names",
+    "rule": "no-invalid-name",
+    "level": "error",
+    "path": "./regression-tests/general/no-invalid-name.yaml",
+    "loc": {
+      "range": [
+        828,
+        845,
+        851
+      ],
+      "startLine": 54,
+      "startColumn": 9,
+      "endLine": 54,
+      "endColumn": 26
+    }
+  },
+  {
+    "message": "Invalid name for PipelineRun '-run-$(uid)'. Names should be in lowercase, alphanumeric, kebab-case format. and follow DNS subdomain names",
+    "rule": "no-invalid-name",
+    "level": "error",
+    "path": "./regression-tests/general/no-invalid-name.yaml",
+    "loc": {
+      "range": [
+        1356,
+        1367,
+        1377
+      ],
+      "startLine": 81,
+      "startColumn": 15,
+      "endLine": 81,
+      "endColumn": 26
+    }
+  },
+  {
+    "message": "TriggerTemplate 'no-invalid-name' references pipeline 'no-invalid-name', but the referenced pipeline cannot be found.",
+    "rule": "no-missing-resource",
+    "level": "error",
+    "path": "./regression-tests/general/no-invalid-name.yaml",
+    "loc": {
+      "range": [
+        1249,
+        1264,
+        1265
+      ],
+      "startLine": 77,
+      "startColumn": 17,
+      "endLine": 77,
+      "endColumn": 32
+    }
+  },
+  {
+    "message": "TriggerTemplate 'no-invalid-name' references pipeline 'no-invalid-name', but the referenced pipeline cannot be found.",
+    "rule": "no-missing-resource",
+    "level": "error",
+    "path": "./regression-tests/general/no-invalid-name.yaml",
+    "loc": {
+      "range": [
+        1426,
+        1441,
+        1442
+      ],
+      "startLine": 84,
+      "startColumn": 17,
+      "endLine": 84,
+      "endColumn": 32
+    }
+  },
+  {
+    "message": "Task 'no-invalid-name' defines parameter 'foo', but it's not used anywhere in the spec",
+    "rule": "no-unused-param",
+    "level": "warning",
+    "path": "./regression-tests/general/no-invalid-name.yaml",
+    "loc": {
+      "range": [
+        1544,
+        1559,
+        1559
+      ],
+      "startLine": 92,
+      "startColumn": 7,
+      "endLine": 93,
+      "endColumn": 1
+    }
+  },
+  {
+    "message": "Task 'no-invalid-name' defines parameter 'foo-', but it's not used anywhere in the spec",
+    "rule": "no-unused-param",
+    "level": "warning",
+    "path": "./regression-tests/general/no-invalid-name.yaml",
+    "loc": {
+      "range": [
+        1565,
+        1581,
+        1581
+      ],
+      "startLine": 93,
+      "startColumn": 7,
+      "endLine": 94,
+      "endColumn": 1
+    }
+  },
+  {
+    "message": "Task 'no-invalid-name' defines parameter 'foo_', but it's not used anywhere in the spec",
+    "rule": "no-unused-param",
+    "level": "warning",
+    "path": "./regression-tests/general/no-invalid-name.yaml",
+    "loc": {
+      "range": [
+        1587,
+        1603,
+        1603
+      ],
+      "startLine": 94,
+      "startColumn": 7,
+      "endLine": 95,
+      "endColumn": 1
+    }
+  },
+  {
+    "message": "Task 'no-invalid-name' defines parameter 'FOO_BAR', but it's not used anywhere in the spec",
+    "rule": "no-unused-param",
+    "level": "warning",
+    "path": "./regression-tests/general/no-invalid-name.yaml",
+    "loc": {
+      "range": [
+        1609,
+        1628,
+        1628
+      ],
+      "startLine": 95,
+      "startColumn": 7,
+      "endLine": 96,
+      "endColumn": 1
+    }
+  },
+  {
+    "message": "Task 'no-invalid-name' defines parameter 'FooBar', but it's not used anywhere in the spec",
+    "rule": "no-unused-param",
+    "level": "warning",
+    "path": "./regression-tests/general/no-invalid-name.yaml",
+    "loc": {
+      "range": [
+        1634,
+        1652,
+        1652
+      ],
+      "startLine": 96,
+      "startColumn": 7,
+      "endLine": 97,
+      "endColumn": 1
+    }
+  },
+  {
+    "message": "Task 'no-invalid-name' defines parameter 'fooBar', but it's not used anywhere in the spec",
+    "rule": "no-unused-param",
+    "level": "warning",
+    "path": "./regression-tests/general/no-invalid-name.yaml",
+    "loc": {
+      "range": [
+        1658,
+        1676,
+        1676
+      ],
+      "startLine": 97,
+      "startColumn": 7,
+      "endLine": 98,
+      "endColumn": 1
+    }
+  },
+  {
+    "message": "Task 'no-invalid-name' defines parameter 'foo-bar', but it's not used anywhere in the spec",
+    "rule": "no-unused-param",
+    "level": "warning",
+    "path": "./regression-tests/general/no-invalid-name.yaml",
+    "loc": {
+      "range": [
+        1682,
+        1701,
+        1701
+      ],
+      "startLine": 98,
+      "startColumn": 7,
+      "endLine": 99,
+      "endColumn": 1
+    }
+  },
+  {
+    "message": "Task 'no-invalid-name' defines parameter 'foo-1-bar', but it's not used anywhere in the spec",
+    "rule": "no-unused-param",
+    "level": "warning",
+    "path": "./regression-tests/general/no-invalid-name.yaml",
+    "loc": {
+      "range": [
+        1707,
+        1728,
+        1728
+      ],
+      "startLine": 99,
+      "startColumn": 7,
+      "endLine": 100,
+      "endColumn": 1
+    }
+  },
+  {
+    "message": "Task 'no-invalid-name' defines parameter 'foo_1-bar', but it's not used anywhere in the spec",
+    "rule": "no-unused-param",
+    "level": "warning",
+    "path": "./regression-tests/general/no-invalid-name.yaml",
+    "loc": {
+      "range": [
+        1734,
+        1755,
+        1755
+      ],
+      "startLine": 100,
+      "startColumn": 7,
+      "endLine": 101,
+      "endColumn": 1
+    }
+  },
+  {
+    "message": "Task 'no-invalid-name' defines parameter '1-foo', but it's not used anywhere in the spec",
+    "rule": "no-unused-param",
+    "level": "warning",
+    "path": "./regression-tests/general/no-invalid-name.yaml",
+    "loc": {
+      "range": [
+        1761,
+        1782,
+        1782
+      ],
+      "startLine": 101,
+      "startColumn": 7,
+      "endLine": 102,
+      "endColumn": 1
+    }
+  },
+  {
+    "message": "Task 'no-invalid-name' defines parameter '-foo', but it's not used anywhere in the spec",
+    "rule": "no-unused-param",
+    "level": "warning",
+    "path": "./regression-tests/general/no-invalid-name.yaml",
+    "loc": {
+      "range": [
+        1788,
+        1808,
+        1808
+      ],
+      "startLine": 102,
+      "startColumn": 7,
+      "endLine": 103,
+      "endColumn": 1
+    }
+  },
+  {
+    "message": "Task 'no-invalid-name' defines parameter '_foo', but it's not used anywhere in the spec",
+    "rule": "no-unused-param",
+    "level": "warning",
+    "path": "./regression-tests/general/no-invalid-name.yaml",
+    "loc": {
+      "range": [
+        1814,
+        1830,
+        1830
+      ],
+      "startLine": 103,
+      "startColumn": 7,
+      "endLine": 104,
+      "endColumn": 1
+    }
+  },
+  {
+    "message": "Task 'no-invalid-name' defines parameter 'foo$bar', but it's not used anywhere in the spec",
+    "rule": "no-unused-param",
+    "level": "warning",
+    "path": "./regression-tests/general/no-invalid-name.yaml",
+    "loc": {
+      "range": [
+        1836,
+        1859,
+        1859
+      ],
+      "startLine": 104,
+      "startColumn": 7,
+      "endLine": 105,
+      "endColumn": 1
+    }
+  }
+]

--- a/regression-tests/general/no-invalid-name.yaml.expect.json
+++ b/regression-tests/general/no-invalid-name.yaml.expect.json
@@ -136,23 +136,6 @@
     }
   },
   {
-    "message": "Invalid name for PipelineRun '-run-$(uid)'. Names should be in lowercase, alphanumeric, kebab-case format. and follow DNS subdomain names",
-    "rule": "no-invalid-name",
-    "level": "error",
-    "path": "./regression-tests/general/no-invalid-name.yaml",
-    "loc": {
-      "range": [
-        1356,
-        1367,
-        1377
-      ],
-      "startLine": 81,
-      "startColumn": 15,
-      "endLine": 81,
-      "endColumn": 26
-    }
-  },
-  {
     "message": "TriggerTemplate 'no-invalid-name' references pipeline 'no-invalid-name', but the referenced pipeline cannot be found.",
     "rule": "no-missing-resource",
     "level": "error",

--- a/src/config.ts
+++ b/src/config.ts
@@ -123,5 +123,4 @@ export class Config {
         const config = new Config(argv);
         return config;
     }
-
 }

--- a/src/rules/no-invalid-name.ts
+++ b/src/rules/no-invalid-name.ts
@@ -1,5 +1,3 @@
-import collectResources from '../collect-resources.js';
-
 const isValidName = (name) => {
     const valid = new RegExp('^[a-zA-Z_][a-z0-9-()$.]*$');
     return valid.test(name);
@@ -39,16 +37,14 @@ export default (docs, tekton, report) => {
     checkInvalidParameterName(tekton.conditions, report);
     checkInvalidParameterName(tekton.triggerTemplates, report);
     checkInvalidParameterName(tekton.pipelines, report);
-    const resources = collectResources(docs);
 
-    for (const [kind, resourceMap] of Object.entries(resources)) {
-        for (const resource of Object.values(resourceMap as any)) {
-            if (!isValidName((resource as any).metadata.name)) {
+    // Check resource names - iterate over docs directly to preserve instrumentation
+    for (const resource of docs) {
+        if (resource.metadata && resource.metadata.name && resource.kind) {
+            if (!isValidName(resource.metadata.name)) {
                 report(
-                    `Invalid name for ${kind} '${
-                        (resource as any).metadata.name
-                    }'. Names should be in lowercase, alphanumeric, kebab-case format. and follow DNS subdomain names`,
-                    (resource as any).metadata,
+                    `Invalid name for ${resource.kind} '${resource.metadata.name}'. Names should be in lowercase, alphanumeric, kebab-case format. and follow DNS subdomain names`,
+                    resource.metadata,
                     'name',
                 );
             }


### PR DESCRIPTION
In order to better understand what's going on I'm first formatting the JSON file in b75988af5397f5fbaed8f69b2d60cecbf1336bf9 and then applying the fix in ab4bb759708fa5ecb3395036fa09281bb196df79.

There were two issues:
- One of the test cases no longer fails -> remove test case
- The linter logic was not properly emitting the `loc`, `path` instrumentation info for this specific test case -> fix instrumentation

This fix was implemented with the help of Bob.