### PR TITLE
build: build for non-EOL Node.js version

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -10,10 +10,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Use Node.js 20
-      uses: actions/setup-node@v1
+    - name: Use Node.js 26
+      uses: actions/setup-node@v6
       with:
-        node-version: 20.x
+        node-version: 26.x
     - run: npm ci
     - run: npm run lint
 
@@ -22,12 +22,12 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x,20.x,21.x]
+        node-version: [22.x, 24.x, 25.x, 26.x]
 
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm ci
@@ -46,7 +46,7 @@ jobs:
         uses: docker/setup-qemu-action@v1
       - name: Setup docker builds
         uses: docker/setup-buildx-action@v1
-      
+
       - name: loging to ghcr
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,22 +14,22 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      
-      - name: Use Node.js 20
-        uses: actions/setup-node@v1
+
+      - name: Use Node.js 26
+        uses: actions/setup-node@v6
         with:
-          node-version: 20.x
+          node-version: 26.x
           registry-url: 'https://registry.npmjs.org'
-      - run: npm ci              
+      - run: npm ci
       - run: npm run build
       - run: npm publish --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}      
-      
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
 
             # - name: Release
             #   uses: softprops/action-gh-release@v1
-            #   with: 
+            #   with:
             #     body_path: CHANGELOG.md
             #     append_body: true
             #     files: tekton-lint-*.tgz

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A linter for Tekton resource definitions
 
 ## Quick Start
 
-Make sure you've NodeJS v18 or later installed, and run....
+Make sure you've NodeJS v22 or later installed, and run....
 
 ```
 npx @ibm/tekton-lint@latest <glob-pattern-to-yaml-files>
@@ -47,9 +47,9 @@ You can use the tool as a regular lint tool from the CLI or scripts; alternative
 
 ## History
 
-When I first started using Tekton a few years ago, I found one of the harder things was keeping track of the dependencies between the YAML files. Comparing to say github actions, or travis, Tekton is a lot more verbose. The comparison isn't quite fair as the tools do work at slightly different levels. 
+When I first started using Tekton a few years ago, I found one of the harder things was keeping track of the dependencies between the YAML files. Comparing to say github actions, or travis, Tekton is a lot more verbose. The comparison isn't quite fair as the tools do work at slightly different levels.
 
-Nevertheless, I was pleased to find this TektonLint tool; it was able to spot a number of the 'gotchas' before pushing the pipelines for execution. 
+Nevertheless, I was pleased to find this TektonLint tool; it was able to spot a number of the 'gotchas' before pushing the pipelines for execution.
 After a brief hiatus, I was using Tekton again.  Bence Dányi the original author was no longer at IBM; as the tool had been useful for me I decided to take on the repo.
 
 I've updated typescript versions, added in additional features such as custom rules, allowed for caching of standard components. Theres more still I'd like to do; but of a MVP it's at v1.
@@ -62,7 +62,7 @@ on the resulting document set. [More details on the pattern syntax.][pattern]
 
 Using `tekton-lint` in watch mode will monitor for any changes in the provided paths and automatically run the linter again.
 
-Be mindful if you specify a glob pattern (eg `*.yaml`) that this might be expanded by your shell rather than the tool itself. It'll probably be fine for the vast majority of cases.  
+Be mindful if you specify a glob pattern (eg `*.yaml`) that this might be expanded by your shell rather than the tool itself. It'll probably be fine for the vast majority of cases.
 
 ```sh
 tekton-lint [<options>]  <glob-pattern-to-yaml-files> ...
@@ -92,7 +92,7 @@ Examples:
 
 ## What yaml files to include?
 
-Only the yaml files that are specified are linted; these can be defined either on the command line, or via the `.tektonlintrc.yaml` file. 
+Only the yaml files that are specified are linted; these can be defined either on the command line, or via the `.tektonlintrc.yaml` file.
 
 ```yaml
 globs:
@@ -117,7 +117,7 @@ external-tasks:
     path: toolchain
   - name: doi-publish-build-record
     uri: https://github.com/open-toolchain/tekton-catalog
-    path: devops-insights    
+    path: devops-insights
   - name: icr-publish
     uri: https://github.com/open-toolchain/tekton-catalog
     path: container-registry
@@ -131,11 +131,11 @@ This will clone the repos specified and extract the various directories to a loc
 Note that these cached files won't be linted themselves.
 
 
-The cache is defined to be put to `~/.tektonlint`  If you wish to clear the cache, simply delete this directory - alternatively there is a cli option. 
+The cache is defined to be put to `~/.tektonlint`  If you wish to clear the cache, simply delete this directory - alternatively there is a cli option.
 
 ## Rules
 
-**Please note** that the tool assumes that the files are syntax correct YAML files, and they are following the established schema for Tekton. For example referring to a field with the wrong spelling or case will confuse the rules. 
+**Please note** that the tool assumes that the files are syntax correct YAML files, and they are following the established schema for Tekton. For example referring to a field with the wrong spelling or case will confuse the rules.
 
 If you see an error like ` Pipeline 'pipeline-test-perf-tag' references task 'undefined' but the referenced task cannot be found. ` referencing 'undefined' this more than likely means there is a syntax error in the yaml file.  This can be easily seen with casing, so using `Name: ..` rather than `name: .. `
 
@@ -240,13 +240,13 @@ external-tasks:
     path: toolchain
   - name: doi-publish-build-record
     uri: https://github.com/open-toolchain/tekton-catalog
-    path: devops-insights    
+    path: devops-insights
   - name: icr-publish
     uri: https://github.com/open-toolchain/tekton-catalog
     path: container-registry
   - name: iks-detch
     uri: https://github.com/open-toolchain/tekton-catalog
-    path: kubernetes-service  
+    path: kubernetes-service
 
 ```
 
@@ -272,8 +272,8 @@ rules:
   ....
 external:tasks:
   ...
-custom: 
- my_rules: custom_rules 
+custom:
+ my_rules: custom_rules
  # For debug and test, refer directly to the js file
  # my_rules: ../customer_rules/my_rules.js
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "typescript": "^5.3.2"
       },
       "engines": {
-        "node": ">= 20.0.0"
+        "node": ">= 22.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -4580,6 +4580,20 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "typescript": "^5.3.2"
   },
   "engines": {
-    "node": ">= 20.0.0"
+    "node": ">= 22.0.0"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
need the failing test case in #122 fixed first

build for all non-EOL Node.js versions:
- remove 18.x, 20.x
- add 22.x, 24.x, 25.x, 26.x

A committer will need to remove the expected checks for 18.x and 20.x from the repo settings.